### PR TITLE
Generate endpoints for querying by single identifier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN go install -v -ldflags "-X main.Version=${VERSION}"
 RUN /go/bin/fint-graphql-cli --version
 
 FROM gcr.io/distroless/static
-COPY --from=builder /go/bin/fint-graphql-cli /usr/bin/fint-graphql-cli
-WORKDIR /src
 VOLUME [ "/src" ]
+WORKDIR /src
+COPY --from=builder /go/bin/fint-graphql-cli /usr/bin/fint-graphql-cli
 ENTRYPOINT [ "/usr/bin/fint-graphql-cli" ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,9 +20,12 @@ pipeline {
                     VERSION = TAG_NAME[1..-1]
                 }
                 sh "echo Version is ${VERSION}"
-                sh "docker build --tag dtr.fintlabs.no/jenkins/fint-graphql-cli:${VERSION} --build-arg VERSION=${VERSION} ."
-                withDockerRegistry([credentialsId: 'dtr-fintlabs-no', url: 'https://dtr.fintlabs.no']) {
-                    sh "docker push dtr.fintlabs.no/jenkins/fint-graphql-cli:${VERSION}"
+                sh "docker build --tag ${GIT_COMMIT} --build-arg VERSION=${VERSION} ."
+                sh "docker tag ${GIT_COMMIT} fint/graphql-cli:${VERSION}"
+                sh "docker tag ${GIT_COMMIT} fint/graphql-cli:latest"
+                withDockerRegistry([credentialsId: 'asgeir-docker', url: '']) {
+                    sh "docker push fint/graphql-cli:${VERSION}"
+                    sh "docker push fint/graphql-cli:latest"
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@ Generates `GraphQL` schemas.
 
 ### Binaries
 
-Precompiled binaries are available as [Docker images](https://dtr.fintlabs.no/)
+Precompiled binaries are available as [Docker images](https://cloud.docker.com/u/fint/repository/docker/fint/graphql-cli)
 
 Mount the directory where you want the generated source code to be written as `/src`.
 
 Linux / MacOS:
 ```bash
-docker run -v $(pwd):/src dtr.fintlabs.no/jenkins/fint-graphql-cli:latest <ARGS>
+docker run -v $(pwd):/src fint/graphql-cli:latest <ARGS>
 ```
 
 Windows PowerShell:
 ```ps1
-docker run -v ${pwd}:/src dtr.fintlabs.no/jenkins/fint-graphql-cli:latest <ARGS>
+docker run -v ${pwd}:/src fint/graphql-cli:latest <ARGS>
 ```
 
 ### Source
@@ -38,4 +38,4 @@ go install github.com/FINTLabs/fint-graphql-cli
 
 ## Author
 
-[FINTProsjektet](https://fintprosjektet.github.io)
+[FINTLabs](https://fintlabs.github.io)

--- a/classes/command.go
+++ b/classes/command.go
@@ -50,6 +50,13 @@ func dumpClass(c *types.Class) {
 		fmt.Printf("    - %s\n", u)
 	}
 
+	if len(c.Identifiers) > 0 {
+		fmt.Println("  Identifiers:")
+		for _, i := range c.Identifiers {
+			fmt.Printf("    - %s\n", i.Name)
+		}
+	}
+
 	if len(c.Attributes) > 0 {
 		fmt.Println("  Attributes:")
 		for _, a := range c.Attributes {

--- a/classes/command.go
+++ b/classes/command.go
@@ -72,7 +72,16 @@ func dumpClass(c *types.Class) {
 			if r.Deprecated {
 				s = "<<DEPRECATED>>"
 			}
-			fmt.Printf("    - %s: %s[%s] <<%s>> %s\n", r.Name, r.Target, r.Multiplicity, r.Stereotype, s)
+			m := ""
+			if r.Optional && r.List {
+				m = "0..*"
+			} else if r.List {
+				m = "1..*"
+			} else {
+				m = "1"
+			}
+
+			fmt.Printf("    - %s: %s[%s] <<%s>> %s\n", r.Name, r.Target, m, r.Stereotype, s)
 		}
 	}
 

--- a/common/parser/parser.go
+++ b/common/parser/parser.go
@@ -382,6 +382,11 @@ func getAssociationsFromExtends(doc *xmlquery.Node, c *xmlquery.Node) ([]types.A
 	return assocs, nil
 }
 
+func getMultiplicity(multiplicity string) (bool, bool) {
+	return strings.HasPrefix(multiplicity, "0"),
+		strings.HasSuffix(multiplicity, "*")
+}
+
 func getAssociations(doc *xmlquery.Node, c *xmlquery.Node) []types.Association {
 	var assocs []types.Association
 	for _, rr := range xmlquery.Find(doc, fmt.Sprintf("//connectors/connector/properties[@ea_type='Association']/../source[@idref='%s']/../target/role", c.SelectAttr("idref"))) {
@@ -389,7 +394,7 @@ func getAssociations(doc *xmlquery.Node, c *xmlquery.Node) []types.Association {
 			assoc := types.Association{}
 			assoc.Name = replaceNO(rr.SelectAttr("name"))
 			assoc.Target = replaceNO(rr.SelectElement("../model").SelectAttr("name"))
-			assoc.Multiplicity = rr.SelectElement("../type").SelectAttr("multiplicity")
+			assoc.Optional, assoc.List = getMultiplicity(rr.SelectElement("../type").SelectAttr("multiplicity"))
 			assoc.Deprecated = rr.SelectElement("../../tags/tag[@name='DEPRECATED']") != nil
 			assoc.TargetPackage = getPackagePath(getClassByIdRef(rr.SelectElement("../../target").SelectAttr("idref"), doc), doc)
 			assocs = append(assocs, assoc)
@@ -400,7 +405,7 @@ func getAssociations(doc *xmlquery.Node, c *xmlquery.Node) []types.Association {
 			assoc := types.Association{}
 			assoc.Name = replaceNO(rl.SelectAttr("name"))
 			assoc.Target = replaceNO(rl.SelectElement("../model").SelectAttr("name"))
-			assoc.Multiplicity = rl.SelectElement("../type").SelectAttr("multiplicity")
+			assoc.Optional, assoc.List = getMultiplicity(rl.SelectElement("../type").SelectAttr("multiplicity"))
 			assoc.Deprecated = rl.SelectElement("../../tags/tag[@name='DEPRECATED']") != nil
 			assoc.TargetPackage = getPackagePath(getClassByIdRef(rl.SelectElement("../../source").SelectAttr("idref"), doc), doc)
 			assocs = append(assocs, assoc)

--- a/common/parser/parser.go
+++ b/common/parser/parser.go
@@ -82,6 +82,7 @@ func GetClasses(owner string, repo string, tag string, filename string, force bo
 		class.Using = getUsing(class, packageMap)
 		class.Identifiable = identifiableFromExtends(class, classMap)
 		class.Resource = isResource(class, classMap)
+		class.Identifiers = getIdentifiers(class, classMap)
 		javaPackageClassMap[class.Package] = append(javaPackageClassMap[class.Package], class)
 		csPackageClassMap[class.Namespace] = append(csPackageClassMap[class.Namespace], class)
 		if len(class.Stereotype) == 0 {
@@ -124,7 +125,7 @@ func GetClasses(owner string, repo string, tag string, filename string, force bo
 		}
 	}
 
-	fmt.Println(" done")
+	fmt.Println(". done")
 	return classes, packageMap, javaPackageClassMap, csPackageClassMap
 }
 
@@ -184,6 +185,25 @@ func identifiable(attribs []types.Attribute) bool {
 
 	return false
 
+}
+
+func getIdentifiers(class *types.Class, classMap map[string]*types.Class) []types.Identifier {
+	var identifiers []types.Identifier
+
+	for _, a := range class.Attributes {
+		if a.Type == "Identifikator" {
+			identifier := types.Identifier{}
+			identifier.Name = a.Name
+			identifier.Optional = a.Optional
+			identifiers = append(identifiers, identifier)
+		}
+	}
+
+	if len(class.Extends) > 0 {
+		identifiers = append(identifiers, getIdentifiers(classMap[class.Extends], classMap)...)
+	}
+
+	return identifiers
 }
 
 func getImports(c *types.Class, imports map[string]types.Import) []string {

--- a/common/types/association.go
+++ b/common/types/association.go
@@ -5,6 +5,7 @@ type Association struct {
 	Target        string
 	TargetPackage string
 	Deprecated    bool
-	Multiplicity  string
+	Optional      bool
+	List          bool
 	Stereotype    string
 }

--- a/common/types/class.go
+++ b/common/types/class.go
@@ -19,4 +19,5 @@ type Class struct {
 	Identifiable              bool
 	GitTag                    string
 	Stereotype                string
+	Identifiers               []Identifier
 }

--- a/common/types/graphql_types.go
+++ b/common/types/graphql_types.go
@@ -34,7 +34,7 @@ func GetGraphQlType(att *Attribute) string {
 
 func GetGraphQlRelationType(rel *Association) string {
 	if rel.Stereotype != "hovedklasse" {
-		return "String"
+		return "[String]"
 	}
 
 	result := rel.Target

--- a/common/types/graphql_types.go
+++ b/common/types/graphql_types.go
@@ -31,3 +31,21 @@ func GetGraphQlType(att *Attribute) string {
 
 	return result
 }
+
+func GetGraphQlRelationType(rel *Association) string {
+	if rel.Stereotype != "hovedklasse" {
+		return "String"
+	}
+
+	result := rel.Target
+
+	if rel.List {
+		result = "[" + result + "]"
+	}
+
+	if !rel.Optional {
+		result = result + "!"
+	}
+
+	return result
+}

--- a/common/types/identifier.go
+++ b/common/types/identifier.go
@@ -1,0 +1,6 @@
+package types
+
+type Identifier struct {
+	Name     string
+	Optional bool
+}

--- a/generate/generator.go
+++ b/generate/generator.go
@@ -123,6 +123,23 @@ func GetGraphQlResolver(c *types.Class) string {
 	return getClass(c, graphql.RESOLVER_TEMPLATE)
 }
 
+func GetGraphQlRootSchema(classes []*types.Class) string {
+	tpl := template.New("schema").Funcs(funcMap)
+
+	parse, err := tpl.Parse(graphql.ROOT_TEMPLATE)
+
+	if err != nil {
+		panic(err)
+	}
+
+	var b bytes.Buffer
+	err = parse.Execute(&b, classes)
+	if err != nil {
+		panic(err)
+	}
+	return b.String()
+}
+
 func GetEndpoints(r []string) string {
 	var funcs = template.FuncMap{
 		"dots": func(s string) string { return strings.Replace(s, "/", ".", -1) },

--- a/generate/generator.go
+++ b/generate/generator.go
@@ -45,13 +45,14 @@ var funcMap = template.FuncMap{
 		}
 		return typ
 	},
-	"component":      types.GetComponentName,
-	"graphqlType":    types.GetGraphQlType,
-	"lowerCase":      func(s string) string { return strings.ToLower(s) },
-	"upperCase":      func(s string) string { return strings.ToUpper(s) },
-	"upperCaseFirst": func(s string) string { return strings.Title(s) },
-	"getter":         func(s string) string { return "get" + strings.Title(s) + "()" },
-	"baseType":       func(s string) string { return strings.Replace(s, "Resource", "", -1) },
+	"component":       types.GetComponentName,
+	"graphqlType":     types.GetGraphQlType,
+	"graphqlRelation": types.GetGraphQlRelationType,
+	"lowerCase":       func(s string) string { return strings.ToLower(s) },
+	"upperCase":       func(s string) string { return strings.ToUpper(s) },
+	"upperCaseFirst":  func(s string) string { return strings.Title(s) },
+	"getter":          func(s string) string { return "get" + strings.Title(s) + "()" },
+	"baseType":        func(s string) string { return strings.Replace(s, "Resource", "", -1) },
 	"assignResource": func(typ string, att string) string {
 		if strings.HasPrefix(typ, "List<") {
 			inner := strings.TrimSuffix(strings.TrimPrefix(typ, "List<"), ">")
@@ -80,12 +81,6 @@ var funcMap = template.FuncMap{
 		}
 
 		return u
-	},
-	"graphqlRelation": func(t *types.Association) string {
-		if t.Stereotype == "hovedklasse" {
-			return t.Target
-		}
-		return "String"
 	},
 	"getEndpoint": func(r string) string { return "get" + strings.Title(GetEndpointName(r)) + "()" },
 }

--- a/generate/generator.go
+++ b/generate/generator.go
@@ -48,11 +48,17 @@ var funcMap = template.FuncMap{
 	"component":       types.GetComponentName,
 	"graphqlType":     types.GetGraphQlType,
 	"graphqlRelation": types.GetGraphQlRelationType,
-	"lowerCase":       func(s string) string { return strings.ToLower(s) },
-	"upperCase":       func(s string) string { return strings.ToUpper(s) },
-	"upperCaseFirst":  func(s string) string { return strings.Title(s) },
-	"getter":          func(s string) string { return "get" + strings.Title(s) + "()" },
-	"baseType":        func(s string) string { return strings.Replace(s, "Resource", "", -1) },
+	"relTargetType": func(a *types.Association) string {
+		if a.List {
+			return fmt.Sprintf("List<%sResource>", a.Target)
+		}
+		return a.Target + "Resource"
+	},
+	"lowerCase":      func(s string) string { return strings.ToLower(s) },
+	"upperCase":      func(s string) string { return strings.ToUpper(s) },
+	"upperCaseFirst": func(s string) string { return strings.Title(s) },
+	"getter":         func(s string) string { return "get" + strings.Title(s) + "()" },
+	"baseType":       func(s string) string { return strings.Replace(s, "Resource", "", -1) },
 	"assignResource": func(typ string, att string) string {
 		if strings.HasPrefix(typ, "List<") {
 			inner := strings.TrimSuffix(strings.TrimPrefix(typ, "List<"), ">")

--- a/generate/graphql/query_resolver_tpl.go
+++ b/generate/graphql/query_resolver_tpl.go
@@ -7,11 +7,9 @@ package no.fint.graphql.model.{{ component .Package }}.{{ lowerCase .Name}};
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
 import {{resourcePkg .Package}}.{{ .Name }}Resource;
-import {{resourcePkg .Package}}.{{ .Name }}Resources;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component("{{component .Package}}{{.Name}}QueryResolver")
 public class {{ .Name }}QueryResolver implements GraphQLQueryResolver {
@@ -19,9 +17,17 @@ public class {{ .Name }}QueryResolver implements GraphQLQueryResolver {
     @Autowired
     private {{ .Name }}Service service;
 
-    public List<{{ .Name }}Resource> get{{ .Name }}(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        {{ .Name }}Resources resources = service.get{{ .Name }}Resources(sinceTimeStamp, dfe);
-        return resources.getContent();
+    public {{ .Name }}Resource get{{ .Name }}(
+{{- range $i, $ident := .Identifiers }}
+            String {{ .Name }},
+{{- end }}
+            DataFetchingEnvironment dfe) {
+{{- range $i, $ident := .Identifiers }}
+        if (StringUtils.isNotEmpty({{ .Name }})) {
+            return service.get{{ $.Name }}ResourceById("{{ lowerCase .Name }}", {{.Name}}, dfe);
+        }
+{{- end }}
+        return null;
     }
 }
 `

--- a/generate/graphql/resolver_tpl.go
+++ b/generate/graphql/resolver_tpl.go
@@ -6,30 +6,30 @@ package no.fint.graphql.model.{{ component .Package }}.{{ lowerCase .Name}};
 
 import com.coxautodev.graphql.tools.GraphQLResolver;
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.Links;
 
-{{ $ur := uniqueRelationTargets .Relations}}
-
-{{ if $ur }}
-{{- range $i, $rel := $ur }}
+{{ $ur := uniqueRelationTargets .Relations -}}
+{{- if $ur -}}
+{{- range $i, $rel := $ur -}}
 import no.fint.graphql.model.{{ component $rel.TargetPackage }}.{{ lowerCase $rel.Target}}.{{ upperCaseFirst $rel.Target }}Service;
+{{ end -}}
 {{- end }}
-{{ end }}
 
+import no.fint.model.resource.Link;
 import {{resourcePkg .Package}}.{{ .Name}}Resource;
-
-{{ if $ur }}
+{{- if $ur -}}
 {{- range $i, $rel := $ur }}
 import {{ resourcePkg $rel.TargetPackage }}.{{ $rel.Target }}Resource;
+{{- end -}}
 {{- end }}
-{{ end }}
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component("{{component .Package}}{{.Name}}Resolver")
 public class {{ .Name }}Resolver implements GraphQLResolver<{{ .Name }}Resource> {
-
 {{ if $ur -}}
 {{- range $i, $rel := $ur }}
     @Autowired
@@ -39,10 +39,16 @@ public class {{ .Name }}Resolver implements GraphQLResolver<{{ .Name }}Resource>
 
 {{ range $i, $rel := .Relations -}}
 {{- if eq $rel.Stereotype "hovedklasse" }}
-    public {{ $rel.Target}}Resource get{{ $rel.Name | upperCaseFirst }}({{ $.Name }}Resource {{ lowerCase $.Name}}, DataFetchingEnvironment dfe) {
-        return {{ lowerCase $rel.Target}}Service.get{{ $rel.Target}}Resource(
-            Links.get({{ lowerCase $.Name}}.get{{ $rel.Name | upperCaseFirst }}()),
-            dfe);
+    public {{ $rel | relTargetType }} get{{ $rel.Name | upperCaseFirst }}({{ $.Name }}Resource {{ lowerCase $.Name}}, DataFetchingEnvironment dfe) {
+        return {{ lowerCase $.Name}}.get{{ $rel.Name | upperCaseFirst }}()
+            .stream()
+            .map(Link::getHref)
+            .map(l -> {{ lowerCase $rel.Target}}Service.get{{ $rel.Target}}Resource(l, dfe))
+            {{ if $rel.List -}}
+                .collect(Collectors.toList());
+            {{- else -}}
+                .findFirst().orElse(null);
+            {{- end }}
     }
 {{ end -}}
 {{- end }}

--- a/generate/graphql/resolver_tpl.go
+++ b/generate/graphql/resolver_tpl.go
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component("{{component .Package}}{{.Name}}Resolver")
@@ -41,14 +42,15 @@ public class {{ .Name }}Resolver implements GraphQLResolver<{{ .Name }}Resource>
 {{- if eq $rel.Stereotype "hovedklasse" }}
     public {{ $rel | relTargetType }} get{{ $rel.Name | upperCaseFirst }}({{ $.Name }}Resource {{ lowerCase $.Name}}, DataFetchingEnvironment dfe) {
         return {{ lowerCase $.Name}}.get{{ $rel.Name | upperCaseFirst }}()
-            .stream()
-            .map(Link::getHref)
-            .map(l -> {{ lowerCase $rel.Target}}Service.get{{ $rel.Target}}Resource(l, dfe))
-            {{ if $rel.List -}}
-                .collect(Collectors.toList());
-            {{- else -}}
-                .findFirst().orElse(null);
-            {{- end }}
+                .stream()
+                .map(Link::getHref)
+                .map(l -> {{ lowerCase $rel.Target}}Service.get{{ $rel.Target}}Resource(l, dfe))
+                .filter(Objects::nonNull)
+                {{ if $rel.List -}}
+                    .collect(Collectors.toList());
+                {{- else -}}
+                    .findFirst().orElse(null);
+                {{- end }}
     }
 {{ end -}}
 {{- end }}

--- a/generate/graphql/root_tpl.go
+++ b/generate/graphql/root_tpl.go
@@ -1,0 +1,11 @@
+package graphql
+
+const ROOT_TEMPLATE = `# java.util.Date implementation
+scalar Date
+
+type Query {
+{{- range . }}
+	{{ lowerCase .Name }}({{range $i,$e := .Identifiers}}{{if $i}}, {{end}}{{.Name}}: String{{end}}): {{ .Name }}
+{{- end }}
+}
+`

--- a/generate/graphql/schema_tpl.go
+++ b/generate/graphql/schema_tpl.go
@@ -6,7 +6,7 @@ type {{ .Name }} {
 {{- if .AttributesWithInheritance }}
 	# Attributes
     {{- range $att := .AttributesWithInheritance }}
-    {{ $att.Name }}: {{ graphqlType $att }}
+    {{ $att.Name }}: {{ $att | graphqlType }}
     {{- end }}
 {{- end }}
 

--- a/generate/graphql/service_tpl.go
+++ b/generate/graphql/service_tpl.go
@@ -5,11 +5,9 @@ const SERVICE_TEMPLATE = `// Built from tag {{ .GitTag }}
 package no.fint.graphql.model.{{ component .Package }}.{{ lowerCase .Name}};
 
 import graphql.schema.DataFetchingEnvironment;
-import no.fint.graphql.ResourceUrlBuilder;
 import no.fint.graphql.WebClientRequest;
 import no.fint.graphql.model.Endpoints;
 import {{resourcePkg .Package}}.{{ .Name }}Resource;
-import {{resourcePkg .Package}}.{{ .Name }}Resources;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -22,13 +20,14 @@ public class {{ .Name }}Service {
     @Autowired
     private Endpoints endpoints;
 
-    public {{ .Name }}Resources get{{ .Name }}Resources(String sinceTimeStamp, DataFetchingEnvironment dfe) {
-        return webClientRequest.get(
-                ResourceUrlBuilder.urlWithQueryParams(
-                    endpoints.{{ .Package | getPathFromPackage | getEndpoint }} + "/{{ lowerCase .Name }}",
-                    sinceTimeStamp),
-                {{ .Name }}Resources.class,
-                dfe);
+    public {{ .Name }}Resource get{{ .Name }}ResourceById(String id, String value, DataFetchingEnvironment dfe) {
+        return get{{ .Name }}Resource(
+            endpoints.{{ .Package | getPathFromPackage | getEndpoint }} 
+                + "/{{ lowerCase .Name }}/" 
+                + id 
+                + "/" 
+                + value,
+            dfe);
     }
 
     public {{ .Name }}Resource get{{ .Name }}Resource(String url, DataFetchingEnvironment dfe) {


### PR DESCRIPTION
This PR removes the collection query methods and replaces them with single-item queries by identifiers.

It also respects multiplicity for relations, meaning resolvers and types correctly indicate relations that have a multiplicity of `1`, `0..*` or `1..*`.